### PR TITLE
ci: fix Codex responses endpoint override

### DIFF
--- a/.github/CI_CD_SETUP.md
+++ b/.github/CI_CD_SETUP.md
@@ -98,7 +98,7 @@
 
 ### Secrets（可选）
 
-- `OPENAI_BASE_URL`：如使用 OpenAI 兼容网关/自建网关，可填 base url（默认走 `https://api.openai.com/v1`）
+- `OPENAI_BASE_URL`：如使用 OpenAI 兼容网关/自建网关，可填网关地址（推荐填到 `/v1` 或完整的 `/v1/responses`；workflow 会自动补全 `/responses`）。不填则使用 `openai/codex-action` 内置默认端点。
 - `ANTHROPIC_BASE_URL`：如使用 Anthropic 兼容网关/自建网关，可填 base url
 
 ### Variables（可选）

--- a/.github/workflows/codex-issue-triage.yml
+++ b/.github/workflows/codex-issue-triage.yml
@@ -23,6 +23,20 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Compute Responses API endpoint override (optional)
+        id: responses_endpoint
+        shell: bash
+        run: |
+          base="${{ secrets.OPENAI_BASE_URL }}"
+          base="${base%/}"
+          if [ -z "$base" ]; then
+            echo "endpoint=" >> "$GITHUB_OUTPUT"
+          elif [[ "$base" == */responses ]]; then
+            echo "endpoint=$base" >> "$GITHUB_OUTPUT"
+          else
+            echo "endpoint=$base/responses" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run Codex triage
         id: run_codex
         uses: openai/codex-action@v1
@@ -33,7 +47,8 @@ jobs:
           ISSUE_REPO: ${{ github.repository }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL || 'https://api.openai.com/v1' }}
+          # NOTE: openai/codex-action expects a full Responses endpoint (…/v1/responses).
+          responses-api-endpoint: ${{ steps.responses_endpoint.outputs.endpoint }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
           effort: ${{ vars.OPENAI_EFFORT || 'medium' }}
           sandbox: read-only
@@ -150,4 +165,3 @@ jobs:
                 await github.rest.issues.createComment({ owner, repo, issue_number, body });
               }
             }
-

--- a/.github/workflows/codex-pr-description.yml
+++ b/.github/workflows/codex-pr-description.yml
@@ -24,6 +24,20 @@ jobs:
             exit 1
           fi
 
+      - name: Compute Responses API endpoint override (optional)
+        id: responses_endpoint
+        shell: bash
+        run: |
+          base="${{ secrets.OPENAI_BASE_URL }}"
+          base="${base%/}"
+          if [ -z "$base" ]; then
+            echo "endpoint=" >> "$GITHUB_OUTPUT"
+          elif [[ "$base" == */responses ]]; then
+            echo "endpoint=$base" >> "$GITHUB_OUTPUT"
+          else
+            echo "endpoint=$base/responses" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout base (safe)
         uses: actions/checkout@v5
         with:
@@ -40,7 +54,8 @@ jobs:
           PR_REPO: ${{ github.repository }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL || 'https://api.openai.com/v1' }}
+          # NOTE: openai/codex-action expects a full Responses endpoint (…/v1/responses).
+          responses-api-endpoint: ${{ steps.responses_endpoint.outputs.endpoint }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
           effort: ${{ vars.OPENAI_EFFORT || 'medium' }}
           sandbox: read-only

--- a/.github/workflows/codex-pr-review.yml
+++ b/.github/workflows/codex-pr-review.yml
@@ -25,6 +25,20 @@ jobs:
             exit 1
           fi
 
+      - name: Compute Responses API endpoint override (optional)
+        id: responses_endpoint
+        shell: bash
+        run: |
+          base="${{ secrets.OPENAI_BASE_URL }}"
+          base="${base%/}"
+          if [ -z "$base" ]; then
+            echo "endpoint=" >> "$GITHUB_OUTPUT"
+          elif [[ "$base" == */responses ]]; then
+            echo "endpoint=$base" >> "$GITHUB_OUTPUT"
+          else
+            echo "endpoint=$base/responses" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Checkout base branch (safe)
         uses: actions/checkout@v5
         with:
@@ -41,7 +55,8 @@ jobs:
           PR_REPO: ${{ github.repository }}
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          responses-api-endpoint: ${{ secrets.OPENAI_BASE_URL || 'https://api.openai.com/v1' }}
+          # NOTE: openai/codex-action expects a full Responses endpoint (…/v1/responses).
+          responses-api-endpoint: ${{ steps.responses_endpoint.outputs.endpoint }}
           model: ${{ vars.OPENAI_MODEL || 'gpt-5.2' }}
           effort: ${{ vars.OPENAI_EFFORT || 'high' }}
           sandbox: read-only

--- a/test.md
+++ b/test.md
@@ -8,6 +8,8 @@
 - `ANTHROPIC_API_KEY`（Claude PR Review / Issue workflows 会用到）
 
 > `OPENAI_BASE_URL` / `ANTHROPIC_BASE_URL` 只有你用代理/兼容网关时才需要；不配会走默认。
+>
+> 注意：`openai/codex-action` 用的是 **Responses API**（最终会请求 `…/v1/responses`）。本仓库 workflow 允许你把 `OPENAI_BASE_URL` 填到 `…/v1` 或 `…/v1/responses`，会自动补全到正确的 `…/responses` 端点。
 
 ## 重要：`pull_request_target` 工作流从“默认分支”读取
 


### PR DESCRIPTION
Fix openai/codex-action `responses-api-endpoint` handling so OPENAI_BASE_URL can be set to `?/v1` or `?/v1/responses` (workflow computes the final `?/responses` endpoint).

This unblocks Codex PR Review / PR Description / Issue Triage when using a custom gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API base URL configuration guidance with recommended endpoint path formats and auto-completion behavior.

* **Chores**
  * Enhanced CI/CD workflows to dynamically compute and normalize API endpoints, improving setup reliability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->